### PR TITLE
Fix docs.rs build process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jay Kickliter <jay@kickliter.com>", "Kenan Sulayman <kenan@sly.mn>", "Knut Nesheim <knutin@gmail.com>"]
 build = "build.rs"
 name = "traildb"
-version = "0.6.0"
+version = "0.6.1"
 
 description = "Binding for TrailDB, an efficient tool for storing and querying series of events."
 license = "MIT"
@@ -22,3 +22,9 @@ traildb-sys = "0.6.3"
 prettytable-rs = "0.8.0"
 uuid = { version = "0.7.4", features = ["v4"] }
 tempdir = "0.3.7"
+
+[features]
+docs-rs = []
+
+[package.metadata.docs.rs]
+features = [ "docs-rs" ] # This feature will be enabled during the docs.rs build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-traildb = "0.5.0"
+traildb = "0.6.1"
 ```
 
 At the moment there's no documentation, but a good starting point is

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "docs-rs")]
+fn main() {} // skip the build script when this is run by docs.rs
+
+#[cfg(not(feature = "docs-rs"))]
 fn main() {
     println!("cargo:rustc-link-lib=static=traildb");
 


### PR DESCRIPTION
This is needed because when build is run by the dosc.rs system,
the build will fail because the build script will not find the libarchive.

Link to the failed docs.rs build https://docs.rs/crate/traildb/0.6.0/builds/192106