### PR TITLE
Fix soundness bug on Multicursor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,6 @@ mod tests {
     extern crate uuid;
     use self::tempdir::TempDir;
     use super::{Constructor, Cursor, Db, EventFilter, MultiCursor, MultiEvent};
-    use std::cell::RefCell;
     use std::collections::HashSet;
     use std::iter::FromIterator;
 
@@ -777,13 +776,11 @@ mod tests {
 
         let db = Db::open(&path).unwrap();
 
-        let cursors = vec![RefCell::new(db.cursor()), RefCell::new(db.cursor())];
-        let mut multi_cursor = MultiCursor::new(&cursors);
-        let mut cursor1 = cursors[0].borrow_mut();
-        let mut cursor2 = cursors[1].borrow_mut();
+        let mut cursors = vec![db.cursor(), db.cursor()];
+        assert!(cursors[0].get_trail(0).is_ok());
+        assert!(cursors[1].get_trail(1).is_ok());
 
-        assert!(cursor1.get_trail(0).is_ok());
-        assert!(cursor2.get_trail(1).is_ok());
+        let mut multi_cursor: MultiCursor = cursors.iter().collect();
         multi_cursor.reset();
 
         let multi_events: Vec<MultiEvent> = multi_cursor.collect();


### PR DESCRIPTION
MultiCursor is currently unsound because of wrong lifetime. For example following example crashes with use-after-free.

```rust
    let multi = {
        let mut cursor = db.cursor();
        cursor.get_trail(0).unwrap();
        let cursors = vec![std::cell::RefCell::new(cursor)];
        traildb::MultiCursor::new(&cursors)
    };

    for _ev in multi {
        //
    }
```

with valgrind output
```
==1193941== Invalid read of size 8
==1193941==    at 0x15F269: tdb_cursor_next (traildb.h:304)
==1193941==    by 0x15F269: tdb_multi_cursor_next (tdb_multi_cursor.c:190)
==1193941==    by 0x14E536: <traildb::MultiCursor as core::iter::traits::iterator::Iterator>::next (lib.rs:519)
==1193941==    by 0x11AC82: simple::main (simple.rs:52)
==1193941==    by 0x11CFDF: std::rt::lang_start::{{closure}} (rt.rs:67)
==1193941==    by 0x16A322: {{closure}} (rt.rs:52)
==1193941==    by 0x16A322: std::panicking::try::do_call (panicking.rs:305)
==1193941==    by 0x16C266: __rust_maybe_catch_panic (lib.rs:86)
==1193941==    by 0x16ACFF: try<i32,closure-0> (panicking.rs:281)
==1193941==    by 0x16ACFF: catch_unwind<closure-0,i32> (panic.rs:394)
==1193941==    by 0x16ACFF: std::rt::lang_start_internal (rt.rs:51)
==1193941==    by 0x11CFB8: std::rt::lang_start (rt.rs:67)
==1193941==    by 0x11B119: main (in /home/jihyun/r/g/traildb-rust/target/debug/examples/simple)
==1193941==  Address 0x73f85e0 is 16 bytes inside a block of size 24 free'd
==1193941==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1193941==    by 0x14E1E1: <traildb::Cursor as core::ops::drop::Drop>::drop (lib.rs:460)
==1193941==    by 0x1534DE: core::ptr::drop_in_place (mod.rs:174)
==1193941==    by 0x11853E: core::ptr::drop_in_place (mod.rs:174)
==1193941==    by 0x118526: core::ptr::drop_in_place (mod.rs:174)
==1193941==    by 0x1188D4: core::ptr::drop_in_place (mod.rs:174)
==1193941==    by 0x116119: <alloc::vec::Vec<T> as core::ops::drop::Drop>::drop (vec.rs:2320)
==1193941==    by 0x118680: core::ptr::drop_in_place (mod.rs:174)
==1193941==    by 0x11AC3E: simple::main (simple.rs:50)
==1193941==    by 0x11CFDF: std::rt::lang_start::{{closure}} (rt.rs:67)
==1193941==    by 0x16A322: {{closure}} (rt.rs:52)
==1193941==    by 0x16A322: std::panicking::try::do_call (panicking.rs:305)
==1193941==    by 0x16C266: __rust_maybe_catch_panic (lib.rs:86)
```

I make following changes
 - fix lifetime annotation on MultiCursor::new
 - remove std::cell::RefCell from MultiCursor::new. I'm not sure why it uses RefCell, but it seems it's okay without RefCell.
 - rustfmt
 - add MultiCursor::from_iter. It allows users to write more ergonomic code like,

```rust
let cursors = vec![cursor];
let multi: traildb::MultiCursor = cursors.iter().collect(); // could be shorter if compiler could infer correct type for multi
```